### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
+os: [
+    "linux"
+]
 node_js:
   - lts/*
 cache:
   yarn: true
-sudo: false
 notifications:
   email: false


### PR DESCRIPTION
### Description
Remove sudo from Travis build and set OS to Linux.
This removes all warnings from the config validation of TravisCI.

### Test Scenarios
 - Check the Travis build of this PR under "config", the status should be green without any warnings.
