### PR TITLE
Fix typo in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ What is the expected behavior that is expected by the changes of the PR?
  - The page should no longer show the mentioned symbol at...
 
 ### Additional information
-Add here additional information if applicable or remove this section-
+Add here additional information if applicable or remove this section.
 
 #### Checklist
 Use the following checklist to ensure your PR meets all contribution requirements.


### PR DESCRIPTION
### Description
Fixes a typo in the PR template were a dash is used instead of a full stop at the end of a phrase.
