### PR TITLE
Define node version firmly

### DIFF
--- a/.docker/node/Dockerfile
+++ b/.docker/node/Dockerfile
@@ -1,5 +1,5 @@
 # SoftDocLinker development image based on current node lts (as CI also uses lts)
-FROM node:lts-alpine
+FROM node:12.18.2-alpine
 
 WORKDIR /srv/softdoclinker
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.18.2]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Description
Set a static Node version to prevent future LTS updates from automatically changing the currently used version as this could lead into issues.

### Issue relations
Closes #41 

### Test Scenarios

- Check if the Docker container still boots and runs with Node 12.18.2.
- Check that the GitHub Actions task "CI" is now using Node 12.18.2.
